### PR TITLE
copy typos configuration from mileston-3-4

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,3 @@
+[default.extend-identifiers]
+Hask = "Hask"
+publically = "publically"

--- a/flake.nix
+++ b/flake.nix
@@ -77,10 +77,12 @@
             deadnix.enable = true;
             statix.enable = true;
             cabal-fmt.enable = true;
-            # TODO(chfanghr): Configuration for ormolu
             ormolu.enable = true;
             shellcheck.enable = true;
-            typos.enable = true;
+            typos = {
+              enable = true;
+              settings.configPath = "./.typos.toml";
+            };
             markdownlint.enable = true;
           };
         };


### PR DESCRIPTION
To make it see `publically` and `Hask` as valid words